### PR TITLE
Move KSP extension out of android

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,16 +156,16 @@ android {
             }
         }
     }
-
-    ksp {
-        arg("room.schemaLocation", "$projectDir/schemas")
-    }
 }
 
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
     }
+}
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 dependencies {


### PR DESCRIPTION
It's an extension of project instead of `android` extension.