### PR TITLE
修复由于"pwd".exec()导致Windows上构建错误的问题

### DIFF
--- a/buildSrc/src/main/kotlin/AppConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AppConfiguration.kt
@@ -26,7 +26,7 @@ object AppConfiguration {
     }
 
     private fun initConfigurations() {
-        val googleServicesJsonPath = "pwd".exec() + "/app/google-services.json"
+        val googleServicesJsonPath = "${System.getProperty("user.dir")}/app/google-services.json"
         val googleServicesJsonFile = File(googleServicesJsonPath)
         googleServicesAvailable =
             googleServicesJsonFile.exists() && googleServicesJsonFile.readText().let {


### PR DESCRIPTION
修复跨平台兼容性：将"pwd".exec()替换为System.getProperty("user.dir")