### PR TITLE
feat: Implement BilibiliSponsorBlock integration

### DIFF
--- a/app/shared/build.gradle.kts
+++ b/app/shared/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
     api(project(mapOf("path" to ":bili-subtitle")))
     api(project(mapOf("path" to ":player")))
     api(project(mapOf("path" to ":utils")))
+    api(project(mapOf("path" to ":sponsorblock")))
     testImplementation(androidx.room.testing)
     testImplementation(libs.kotlin.test)
     androidTestImplementation(androidx.compose.ui.test.junit4)

--- a/app/shared/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
+++ b/app/shared/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
@@ -22,6 +22,8 @@ import dev.aaa1115910.bv.player.entity.Audio
 import dev.aaa1115910.bv.player.entity.DanmakuType
 import dev.aaa1115910.bv.player.entity.Resolution
 import dev.aaa1115910.bv.player.entity.VideoCodec
+import dev.aaa1115910.bv.sponsorblock.entity.SegmentCategory
+import dev.aaa1115910.bv.sponsorblock.entity.SponsorBlockSetting
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -311,6 +313,21 @@ object Prefs {
     val themeTypeFlow: Flow<ThemeType>
         get() = dsm.getPreferenceFlow(PrefKeys.prefThemeTypeRequest)
             .transform { ordinal -> emit(ThemeType.entries[ordinal]) }
+
+    var enableSponsorBlock: Boolean
+        get() = runBlocking { dsm.getPreferenceFlow(PrefKeys.prefEnableSponsorBlockRequest).first() }
+        set(value) = runBlocking { dsm.editPreference(PrefKeys.prefEnableSponsorBlockKey, value) }
+
+    fun getSponsorBlockSetting(category: SegmentCategory): SponsorBlockSetting = runBlocking {
+        SponsorBlockSetting.entries[dsm.getPreferenceFlow(
+            PrefKeys.getSponsorBlockRequest(category)
+        ).first()]
+    }
+
+    fun setSponsorBlockSetting(category: SegmentCategory, setting: SponsorBlockSetting) =
+        runBlocking {
+            dsm.editPreference(PrefKeys.getSponsorBlockKey(category), setting.ordinal)
+        }
 }
 
 object PrefKeys {
@@ -356,6 +373,10 @@ object PrefKeys {
     val prefEnableFfmpegAudioRenderer = booleanPreferencesKey("enable_ffmpeg_audio_renderer")
     val prefBlacklistUserKey = booleanPreferencesKey("blacklist_user")
     val prefThemeTypeKey = intPreferencesKey("theme_type")
+
+    val prefEnableSponsorBlockKey = booleanPreferencesKey("enable_sponsor_block")
+    fun getSponsorBlockKey(category: SegmentCategory) =
+        intPreferencesKey("sponsor_block_${category.name.lowercase()}")
 
     val prefIsLoginRequest = PreferenceRequest(prefIsLoginKey, false)
     val prefUidRequest = PreferenceRequest(prefUidKey, 0)
@@ -413,4 +434,14 @@ object PrefKeys {
     val prefEnableFfmpegEndererRequest = PreferenceRequest(prefEnableFfmpegAudioRenderer, false)
     val prefBlacklistUserRequest = PreferenceRequest(prefBlacklistUserKey, false)
     val prefThemeTypeRequest = PreferenceRequest(prefThemeTypeKey, ThemeType.Auto.ordinal)
+
+    val prefEnableSponsorBlockRequest = PreferenceRequest(prefEnableSponsorBlockKey, false)
+    fun getSponsorBlockRequest(category: SegmentCategory) = PreferenceRequest(
+        key = getSponsorBlockKey(category),
+        defaultValue = when (category) {
+            SegmentCategory.Sponsor -> SponsorBlockSetting.Skip.ordinal
+            SegmentCategory.PoiHighlight -> SponsorBlockSetting.Off.ordinal
+            else -> SponsorBlockSetting.Confirm.ordinal
+        }
+    )
 }

--- a/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/SettingsScreen.kt
+++ b/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import dev.aaa1115910.bv.tv.screens.settings.content.NetworkSetting
 import dev.aaa1115910.bv.tv.screens.settings.content.OtherSetting
 import dev.aaa1115910.bv.tv.screens.settings.content.PlayerTypeSetting
 import dev.aaa1115910.bv.tv.screens.settings.content.ResolutionSetting
+import dev.aaa1115910.bv.tv.screens.settings.content.SponsorBlockSettings
 import dev.aaa1115910.bv.tv.screens.settings.content.StorageSetting
 import dev.aaa1115910.bv.tv.screens.settings.content.UISetting
 import dev.aaa1115910.bv.tv.screens.settings.content.VideoCodecSetting
@@ -165,6 +166,7 @@ enum class SettingsMenuNavItem(private val strRes: Int) {
     VideoCodec(R.string.settings_item_codec),
     Audio(R.string.settings_item_audio),
     PlayerType(R.string.settings_item_player_type),
+    SponsorBlock(R.string.settings_item_sponsor_block),
     UI(R.string.settings_item_ui),
     Api(R.string.settings_item_api),
     Other(R.string.settings_item_other),
@@ -194,6 +196,7 @@ fun SettingContent(
         ) {
             when (currentMenu) {
                 SettingsMenuNavItem.Resolution -> ResolutionSetting()
+                SettingsMenuNavItem.SponsorBlock -> SponsorBlockSettings()
                 SettingsMenuNavItem.Info -> InfoSetting()
                 SettingsMenuNavItem.About -> AboutSetting()
                 SettingsMenuNavItem.VideoCodec -> VideoCodecSetting()

--- a/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/content/SponsorBlockSettings.kt
+++ b/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/content/SponsorBlockSettings.kt
@@ -1,0 +1,86 @@
+package dev.aaa1115910.bv.tv.screens.settings.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import dev.aaa1115910.bv.sponsorblock.entity.SegmentCategory
+import dev.aaa1115910.bv.sponsorblock.entity.SponsorBlockSetting
+import dev.aaa1115910.bv.tv.component.settings.SettingsMenuSelectItem
+import dev.aaa1115910.bv.util.Prefs
+
+@Composable
+fun SponsorBlockSettings(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var enabled by remember { mutableStateOf(Prefs.enableSponsorBlock) }
+
+    Box(
+        modifier = modifier
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "SponsorBlock",
+                style = MaterialTheme.typography.displaySmall
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = "启用 SponsorBlock")
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = {
+                        enabled = it
+                        Prefs.enableSponsorBlock = it
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(items = SegmentCategory.entries) { category ->
+                    var selectedSetting by remember { mutableStateOf(Prefs.getSponsorBlockSetting(category)) }
+                    Text(text = category.title)
+                    Row {
+                        SponsorBlockSetting.entries.forEach { setting ->
+                            SettingsMenuSelectItem(
+                                text = setting.displayName,
+                                selected = selectedSetting == setting,
+                                onClick = {
+                                    selectedSetting = setting
+                                    Prefs.setSponsorBlockSetting(category, setting)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/tv/src/main/res/values/strings.xml
+++ b/app/tv/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="title_activity_user_switch">用户切换</string>
     <string name="title_activity_video_info">视频信息</string>
     <string name="title_activity_video_player_v3">视频播放</string>
+    <string name="settings_item_sponsor_block">SponsorBlock</string>
 </resources>

--- a/player/tv/src/main/kotlin/dev/aaa1115910/bv/player/tv/BvPlayer.kt
+++ b/player/tv/src/main/kotlin/dev/aaa1115910/bv/player/tv/BvPlayer.kt
@@ -62,6 +62,11 @@ import dev.aaa1115910.bv.player.entity.VideoPlayerSeekData
 import dev.aaa1115910.bv.player.entity.VideoPlayerStateData
 import dev.aaa1115910.bv.player.tv.controller.VideoPlayerController
 import dev.aaa1115910.bv.player.util.danmakuMask
+import dev.aaa1115910.bv.sponsorblock.entity.Segment
+import dev.aaa1115910.bv.sponsorblock.entity.SegmentCategory
+import dev.aaa1115910.bv.sponsorblock.entity.SponsorBlockSetting
+import dev.aaa1115910.bv.sponsorblock.net.SponsorBlockClient
+import dev.aaa1115910.bv.util.Prefs
 import dev.aaa1115910.bv.util.countDownTimer
 import dev.aaa1115910.bv.util.fInfo
 import dev.aaa1115910.bv.util.formatHourMinSec
@@ -149,6 +154,12 @@ fun BvPlayer(
     var hideBackToHistoryTimer: CountDownTimer? by remember { mutableStateOf(null) }
 
     var currentDanmakuMaskFrame: DanmakuMaskFrame? by remember { mutableStateOf(null) }
+
+    val sponsorBlockClient = remember { SponsorBlockClient() }
+    var segments by remember { mutableStateOf<List<Segment>>(emptyList()) }
+    var activeSegment by remember { mutableStateOf<Segment?>(null) }
+    var showSkipButton by remember { mutableStateOf(false) }
+    var skipTipTimer: CountDownTimer? by remember { mutableStateOf(null) }
 
     val updateSeek = {
         currentPosition = videoPlayer.currentPosition.coerceAtLeast(0L)
@@ -244,6 +255,52 @@ fun BvPlayer(
             videoPlayerVideoInfoData.width / videoPlayerVideoInfoData.height.toFloat()
         defaultAspectRatio = newAspectRatio.takeIf { it > 0 } ?: (16 / 9f)
         updateVideoAspectRatio()
+    }
+
+    LaunchedEffect(videoPlayerVideoInfoData.bvid) {
+        if (videoPlayerVideoInfoData.bvid.isNotEmpty() && Prefs.enableSponsorBlock) {
+            scope.launch(Dispatchers.IO) {
+                runCatching {
+                    val allSegments = sponsorBlockClient.getSkipSegments(
+                        videoPlayerVideoInfoData.bvid,
+                        videoPlayerVideoInfoData.cid
+                    )
+                    segments = allSegments.flatMap { it.segments }
+                }.onFailure {
+                    logger.error { "Failed to get segments: ${it.stackTraceToString()}" }
+                }
+            }
+        }
+    }
+
+    val showSkipTip: (String) -> Unit = {
+        skipTipTimer?.cancel()
+        // a little hack to show skip tip
+        // I don't want to add a new state to VideoPlayerLogsData
+        videoPlayerLogsData.logs = it
+        skipTipTimer = countDownTimer(3000, 1000, "skipTipTimer") {
+            videoPlayerLogsData.logs = ""
+        }
+    }
+
+    LaunchedEffect(activeSegment) {
+        activeSegment?.let { segment ->
+            val category = SegmentCategory.fromCategoryName(segment.category) ?: return@let
+            val setting = Prefs.getSponsorBlockSetting(category)
+            when (setting) {
+                SponsorBlockSetting.Skip -> {
+                    videoPlayer.seekTo((segment.segment[1] * 1000).toLong())
+                    showSkipTip("已为您跳过 ${category.description} 片段")
+                }
+
+                SponsorBlockSetting.Confirm -> {
+                    showSkipButton = true
+                }
+
+                SponsorBlockSetting.Off -> {
+                }
+            }
+        }
     }
 
     val updateBackToHistory: () -> Unit = {
@@ -348,7 +405,19 @@ fun BvPlayer(
 
     DisposableEffect(Unit) {
         val updateSeekTimer = timeTask(0, 100, "updateSeekTimer", false) {
-            scope.launch { updateSeek() }
+            scope.launch {
+                updateSeek()
+                if (segments.isNotEmpty()) {
+                    val currentSeek = currentPosition / 1000f
+                    val segment = segments.find { currentSeek in it.segment[0]..it.segment[1] }
+                    if (segment != null) {
+                        activeSegment = segment
+                    } else {
+                        activeSegment = null
+                        showSkipButton = false
+                    }
+                }
+            }
         }
         onDispose {
             updateSeekTimer.cancel()
@@ -629,6 +698,15 @@ fun BvPlayer(
                 onSubtitleBottomPadding(padding)
             },
             onRequestFocus = { focusRequester.requestFocus() },
+            showSkipButton = showSkipButton,
+            onSkip = {
+                activeSegment?.let {
+                    videoPlayer.seekTo((it.segment[1] * 1000).toLong())
+                    showSkipButton = false
+                    val category = SegmentCategory.fromCategoryName(it.category)
+                    showSkipTip("已为您跳过 ${category?.description} 片段")
+                }
+            }
         ) {
             LaunchedEffect(Unit) {
                 videoPlayer.setOptions()

--- a/player/tv/src/main/kotlin/dev/aaa1115910/bv/player/tv/controller/VideoPlayerController.kt
+++ b/player/tv/src/main/kotlin/dev/aaa1115910/bv/player/tv/controller/VideoPlayerController.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import dev.aaa1115910.biliapi.entity.video.Subtitle
@@ -80,6 +81,10 @@ fun VideoPlayerController(
     onSubtitleBottomPadding: (Dp) -> Unit,
 
     onRequestFocus: () -> Unit,
+
+    showSkipButton: Boolean,
+    onSkip: () -> Unit,
+
     content: @Composable BoxScope.() -> Unit
 ) {
     val context = LocalContext.current
@@ -329,6 +334,17 @@ fun VideoPlayerController(
         }
         BottomSubtitle()
         SkipTips()
+        if (showSkipButton) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+            ) {
+                Button(onClick = onSkip) {
+                    Text(text = "跳过")
+                }
+            }
+        }
         PlayStateTips()
         ControllerVideoInfo(
             show = showInfo,

--- a/sponsorblock/build.gradle.kts
+++ b/sponsorblock/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    alias(gradleLibs.plugins.kotlin.jvm)
+    alias(gradleLibs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.serialization)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.serialization.kotlinx)
+    implementation(libs.logging)
+
+    testImplementation(libs.kotlin.test)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/Segment.kt
+++ b/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/Segment.kt
@@ -1,0 +1,17 @@
+package dev.aaa1115910.bv.sponsorblock.entity
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Segment(
+    @SerialName("segment")
+    val segment: List<Float>,
+    @SerialName("UUID")
+    val uuid: String,
+    val category: String,
+    val actionType: String,
+    val locked: Int,
+    val votes: Int,
+    val videoDuration: Int
+)

--- a/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/SegmentCategory.kt
+++ b/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/SegmentCategory.kt
@@ -1,0 +1,18 @@
+package dev.aaa1115910.bv.sponsorblock.entity
+
+enum class SegmentCategory(val title: String, val description: String) {
+    Sponsor("sponsor", "广告"),
+    Selfpromo("selfpromo", "无偿/自我推广"),
+    Interaction("interaction", "三连/订阅提醒"),
+    Intro("intro", "过场/开场动画"),
+    Outro("outro", "鸣谢/结束画面"),
+    Preview("preview", "回顾/概要"),
+    MusicOfftopic("music_offtopic", "音乐:非音乐部分"),
+    PoiHighlight("poi_highlight", "精彩时刻/重点"),
+    Filler("filler", "离题闲聊/玩笑");
+
+    companion object {
+        fun fromCategoryName(name: String) =
+            entries.find { it.name.equals(name, ignoreCase = true) }
+    }
+}

--- a/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/SponsorBlockSetting.kt
+++ b/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/SponsorBlockSetting.kt
@@ -1,0 +1,7 @@
+package dev.aaa1115910.bv.sponsorblock.entity
+
+enum class SponsorBlockSetting(val displayName: String) {
+    Off("关闭"),
+    Confirm("确认"),
+    Skip("自动跳过")
+}

--- a/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/Video.kt
+++ b/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/entity/Video.kt
@@ -1,0 +1,9 @@
+package dev.aaa1115910.bv.sponsorblock.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Video(
+    val videoID: String,
+    val segments: List<Segment>
+)

--- a/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/net/SponsorBlockClient.kt
+++ b/sponsorblock/src/main/kotlin/dev/aaa1115910/bv/sponsorblock/net/SponsorBlockClient.kt
@@ -1,0 +1,39 @@
+package dev.aaa1115910.bv.sponsorblock.net
+
+import dev.aaa1115910.bv.sponsorblock.entity.Video
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+
+class SponsorBlockClient {
+    private val client = HttpClient(OkHttp) {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+            }, contentType = ContentType.Any)
+        }
+    }
+
+    private fun sha256(input: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    suspend fun getSkipSegments(bvid: String, cid: Long, vararg categories: String): List<Video> {
+        val hashPrefix = sha256(bvid).substring(0, 4)
+        return client.get("https://bsbsb.top/api/skipSegments/$hashPrefix") {
+            header("x-ext-version", "0.5.0")
+            url {
+                parameters.append("categories", "[\"${categories.joinToString("\",\"")}\"]")
+                parameters.append("cid", cid.toString())
+            }
+        }.body()
+    }
+}


### PR DESCRIPTION
This commit introduces the BilibiliSponsorBlock feature, allowing users to automatically skip sponsored segments in videos.

- Creates a new `sponsorblock` module for modularity.
- Implements a Ktor-based API client for the BilibiliSponsorBlock API.
- Adds a new settings screen to enable/disable the feature and configure the skipping behavior for each segment category.
- Integrates the segment skipping logic into the video player, including automatic skipping, a confirmation button, and a skip notification.